### PR TITLE
[RAG] Fix performance issue using where filter on all selected doc in chromadb

### DIFF
--- a/wattelse/chatbot/frontend/chatbot/static/chatbot/chatbot_functions_v3.js
+++ b/wattelse/chatbot/frontend/chatbot/static/chatbot/chatbot_functions_v3.js
@@ -217,6 +217,12 @@ async function postUserMessageToRAG(userMessage) {
     botDiv.classList.add("waiting-div", "animate");
     chatHistory.scrollTop = chatHistory.scrollHeight;
 
+    // Get selected files
+    let selectedFiles = getSelectedFileNames("available-list");
+    if (selectedFiles.length === availableDocs.length) {
+        selectedFiles = [];
+    }
+
     // Fetch response
     const response = await fetch('query_rag/', {
         method: 'POST',
@@ -224,7 +230,7 @@ async function postUserMessageToRAG(userMessage) {
         body: new URLSearchParams({
             'csrfmiddlewaretoken': csrfmiddlewaretoken,
             'message': userMessage,
-            'selected_docs': JSON.stringify(getSelectedFileNames("available-list")),
+            'selected_docs': JSON.stringify(selectedFiles),
             'conversation_id': conversationId,
         })
     });


### PR DESCRIPTION
Cette modification permet de n'appliquer aucun filtre dans la requête à ChromaDB lorsque tous les documents sont sélectionnés, améliorant largement les performance de retrieval.