### PR TITLE
[SecureGPT] Add max messages parameter

### DIFF
--- a/wattelse/chatbot/frontend/chatbot/secureGPT_views.py
+++ b/wattelse/chatbot/frontend/chatbot/secureGPT_views.py
@@ -27,6 +27,9 @@ from .utils import (
 # NUMBER MAX OF TOKENS
 MAX_TOKENS = 1536
 
+# Max messages in history
+MAX_MESSAGES = 12
+
 
 # Config for retriever and generator
 config = configparser.ConfigParser(
@@ -72,7 +75,7 @@ def request_client(request):
 
         # Get user chat history
         history = get_conversation_history(
-            request.user, conversation_id, ChatModel=GPTChat
+            request.user, conversation_id, ChatModel=GPTChat, n=MAX_MESSAGES
         )
 
         # Get posted message

--- a/wattelse/chatbot/frontend/chatbot/utils.py
+++ b/wattelse/chatbot/frontend/chatbot/utils.py
@@ -105,6 +105,7 @@ def get_conversation_history(
     user: User,
     conversation_id: uuid.UUID,
     ChatModel: models.Model,
+    n: int = 0,
 ) -> List[Dict[str, str]] | None:
     """
     Return chat history following OpenAI API format :
@@ -115,13 +116,15 @@ def get_conversation_history(
         {...}
     ]
     If no history is found return None.
+    Use `n` parameter to only return the last `n` messages.
+    Default `n` value is 0 to return all messages.
     """
     history = []
     history_query = ChatModel.objects.filter(user=user, conversation_id=conversation_id)
     for chat in history_query:
         history.append({"role": "user", "content": chat.message})
         history.append({"role": "assistant", "content": chat.response})
-    return None if len(history) == 0 else history
+    return None if len(history) == 0 else history[-n:]
 
 
 def get_user_conversation_ids(


### PR DESCRIPTION
Petite modification pour ajouter une limite du nombre de messages pris en compte à chaque question.

**Valeur par défaut : 12 messages (6 questions/réponses)**