### PR TITLE
Enlever le mode debug par défaut dans Django

### DIFF
--- a/wattelse/chatbot/frontend/django_chatbot/settings.py
+++ b/wattelse/chatbot/frontend/django_chatbot/settings.py
@@ -38,7 +38,7 @@ DB_DIR.mkdir(parents=True, exist_ok=True)
 SECRET_KEY = "django-insecure-wsa9k4v_goql%t8rn@q4*5flo+xnnxa%8!^p2g(4g-=py==ur)"
 
 # SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = True
+DEBUG = False
 
 ALLOWED_HOSTS = [
     "localhost",

--- a/wattelse/chatbot/frontend/start.sh
+++ b/wattelse/chatbot/frontend/start.sh
@@ -5,4 +5,4 @@
 # This file is part of Wattelse, a NLP application suite.
 #
 
-python manage.py runserver 0.0.0.0:8000
+python manage.py runserver 0.0.0.0:8000 --insecure


### PR DESCRIPTION
Petite PR pour supprimer le mode debug par défaut dans django et éviter d'avoir des messages d'erreurs qui dévoilent nos variables d'environnement.

Il faut lancer Django avec l'argument `--insecure` sinon les fichiers statiques ne sont pas servis par défaut.

Quelques infos sur le mode `--insecure` :
[https://stackoverflow.com/questions/31097333/why-is-serving-static-files-insecure/31097709#31097709](https://stackoverflow.com/questions/31097333/why-is-serving-static-files-insecure/31097709#31097709)